### PR TITLE
fix: prevent waiting for empty event loop

### DIFF
--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -19,12 +19,12 @@ const helloGetHandler = async (req, res) => {
                   }
               }
             : {};
-
         const users = await User.find({ ...emailFilter, ...cursorFilter }, 'name email', {
             limit: 20,
             sort: { _id: 1, email: 1 }
         });
-        res.status(200).json({ success: true, data: users });
+
+        return res.status(200).json({ success: true, data: users });
     } catch (error) {
         res.status(400).json({ success: false });
     }

--- a/utils/mongo.js
+++ b/utils/mongo.js
@@ -1,8 +1,18 @@
 import mongoose from 'mongoose';
 
 export const connectionMiddleware = async (req, res, next) => {
+    const { context } = req.netlifyFunctionParams || {};
+
+    // Lambda functions automatically wait for any external connections to close
+    // As we're not manually disconnecting from mongodb
+    // because we want to reuse the connection (if possible!)
+    // We need to tell Netlify / AWS to respond as soon as we call res.send / res.json
+    // callbackWaitsForEmptyEventLoop -> false forces that behaviour
+    if (context) {
+        context.callbackWaitsForEmptyEventLoop = false;
+    }
+
     if (mongoose.connections[0].readyState) {
-        // Use current db connection
         return next();
     }
     try {
@@ -12,6 +22,7 @@ export const connectionMiddleware = async (req, res, next) => {
             useFindAndModify: false,
             useCreateIndex: true
         });
+
         await next();
     } catch (error) {
         console.log('Database error', error);


### PR DESCRIPTION
When hitting the users API endpoint on production, it would always time out after 10 seconds.

Netlify runs its functions on AWS by default - AWS Lambda functions will automatically wait for any external connections (like to a database) to be closed before responding. 

Since we're not manually closing the database connection after using it, as we WANT to try and reuse a connection where possible it meant that the function never responded and was cancelled after 10 seconds.

This change means that the function will respond as soon as a response is set (res.json or res.send etc).

Happy to talk over it!